### PR TITLE
Use torchvision.transforms v2

### DIFF
--- a/core.ipynb
+++ b/core.ipynb
@@ -98,7 +98,7 @@
    "outputs": [],
    "source": [
     "from datasets import load_dataset\n",
-    "import torchvision.transforms.functional as TF"
+    "import torchvision.transforms.v2.functional as TF"
    ]
   },
   {
@@ -598,7 +598,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -661,7 +660,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -878,7 +876,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -886,7 +883,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -908,7 +904,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -928,7 +923,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -966,7 +960,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -1514,7 +1507,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2274,7 +2266,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -2303,10 +2294,6 @@
    "display_name": "python3",
    "language": "python",
    "name": "python3"
-  },
-  "language_info": {
-   "name": "python",
-   "version": "3.11.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello, 

In this pull request, I am using `torchvision.transforms.v2.functional`, rather than `torchvision.transforms.functional` as [pytorch recommended it](https://pytorch.org/vision/stable/transforms.html#v1-or-v2-which-one-should-i-use).

This is my first pull request. I tried my best to not make any mistake or break anything but let me know if I am doing something wrong. It seems like attachments and python information at the end are deleted. I ran `nbdev_clean`, but nothing changed. I also tried running the whole notebook, but my pull request got very big due to changed images, yb, etc. This change in images probably come from not setting seed. After setting a seed and commit, this issue probably go away in the future.

Please let me know what I need to do. I am here to do the right thing.

